### PR TITLE
Bug fixes

### DIFF
--- a/Rottytooth.Esolang.Folders/ProgramBuilderBasic.cs
+++ b/Rottytooth.Esolang.Folders/ProgramBuilderBasic.cs
@@ -110,7 +110,7 @@ namespace Rottytooth.Esolang.Folders
                     break;
                 case "declare":
                     string variableType = ResolveName(baseDir.GetDirectories()[1].Name);
-                    string variableName = ResolveName(baseDir.GetDirectories()[0].Name);
+                    string variableName = ResolveName(baseDir.GetDirectories()[2].Name);
 
                     declarations.Append("\npublic static ");
                     declarations.Append(variableType);

--- a/Rottytooth.Esolang.Folders/ProgramBuilderBasic.cs
+++ b/Rottytooth.Esolang.Folders/ProgramBuilderBasic.cs
@@ -82,7 +82,9 @@ namespace Rottytooth.Esolang.Folders
                     program.Append(");\n");
                     break;
                 case "input":
-                    ParseExpression(baseDir.GetDirectories()[0].FullName, program);
+                    program.Append(" Var");
+                    subdir = baseDir.GetDirectories();
+                    program.Append(subdir[1].GetDirectories().Length);
                     program.Append(" = Console.ReadLine(");
                     program.Append(");\n");
                     break;

--- a/Rottytooth.Esolang.Folders/ProgramBuilderBasic.cs
+++ b/Rottytooth.Esolang.Folders/ProgramBuilderBasic.cs
@@ -92,7 +92,7 @@ namespace Rottytooth.Esolang.Folders
                     program.Append(")");
                     program.Append("\n{\n");
                     subdir = baseDir.GetDirectories();
-                    for (int i = 1; i < subdir.Length; i++)
+                    for (int i = 0; i < subdir.Length; i++)
                     {
                         ParseCommand(subdir[i].FullName, program, declarations);
                     }

--- a/Rottytooth.Esolang.Folders/ProgramBuilderPure.cs
+++ b/Rottytooth.Esolang.Folders/ProgramBuilderPure.cs
@@ -120,7 +120,8 @@ namespace Rottytooth.Esolang.Folders
                         program.Append(");\n");
                         break;
                     case (int)CommandEnum.Input:
-                        ParseExpression(subDirs[1].FullName, program);
+                        program.Append(" Var");
+                        program.Append(subDirs[1].GetDirectories().Length);
                         program.Append(" = Console.ReadLine(");
                         program.Append(");\n");
                         break;

--- a/Rottytooth.Esolang.Folders/ProgramBuilderPure.cs
+++ b/Rottytooth.Esolang.Folders/ProgramBuilderPure.cs
@@ -86,8 +86,8 @@ namespace Rottytooth.Esolang.Folders
                         program.Append("\n}\n");
                         break;
                     case (int)CommandEnum.Declare:
-                        string variableType = ParseType(baseDir.GetDirectories()[2].FullName).ToString().ToLower();
-                        string variableName = "Var" + baseDir.GetDirectories()[1].GetDirectories().Length.ToString();
+                        string variableType = ParseType(baseDir.GetDirectories()[1].FullName).ToString().ToLower();
+                        string variableName = "Var" + baseDir.GetDirectories()[2].GetDirectories().Length.ToString();
 
                         declarations.Append("\npublic static ");
                         declarations.Append(variableType);

--- a/Rottytooth.Esolang.Folders/ProgramBuilderPure.cs
+++ b/Rottytooth.Esolang.Folders/ProgramBuilderPure.cs
@@ -64,7 +64,7 @@ namespace Rottytooth.Esolang.Folders
 
                         commandDirs = subDirs[2].GetDirectories().CustomSort().ToArray();
 
-                        for (int i = 1; i < commandDirs.Length; i++) // third directory is the list of commands to carry out
+                        for (int i = 0; i < commandDirs.Length; i++) // third directory is the list of commands to carry out
                         {
                             ParseCommand(commandDirs[i].FullName, program, declarations);
                         }


### PR DESCRIPTION
1. Fixed a bug with If Commands - it was skipping the first Command in the Commands list.
2. Fixed a bug with Input Commands - it was expecting an expression instead of a variable name in the 2nd sub-directory
3. Fixed a bug where Declare Commands were expecting type and var name in the incorrect order according to the spec (https://esolangs.org/wiki/Folders).